### PR TITLE
page_mapper api cleanup

### DIFF
--- a/drivers/page_mapper/src/lib.rs
+++ b/drivers/page_mapper/src/lib.rs
@@ -53,25 +53,15 @@ where
         trace!("Mapping page: {:?} -> {:?}", &page, &frame);
 
         let level_4 = self.walker.level4();
-        let translator = self.walker.translator();
 
         let entry = level_4.index_pin_mut(addr.page_table_index(Level4));
-        let level_3 = self
-            .walker
-            .walk_level3(entry)
-            .or_create(flags, translator, allocator)?;
+        let level_3 = self.walker.walk_level3(entry).or_create(flags, allocator)?;
 
         let entry = level_3.index_pin_mut(addr.page_table_index(Level3));
-        let level_2 = self
-            .walker
-            .walk_level2(entry)
-            .or_create(flags, translator, allocator)?;
+        let level_2 = self.walker.walk_level2(entry).or_create(flags, allocator)?;
 
         let entry = level_2.index_pin_mut(addr.page_table_index(Level2));
-        let level_1 = self
-            .walker
-            .walk_level1(entry)
-            .or_create(flags, translator, allocator)?;
+        let level_1 = self.walker.walk_level1(entry).or_create(flags, allocator)?;
 
         // SAFETY: we are the sole owner of this page and the entry will be valid
         unsafe {
@@ -101,19 +91,12 @@ where
         trace!("Mapping page: {:?} -> {:?}", &page, &frame);
 
         let level_4 = self.walker.level4();
-        let translator = self.walker.translator();
 
         let entry = level_4.index_pin_mut(addr.page_table_index(Level4));
-        let level_3 = self
-            .walker
-            .walk_level3(entry)
-            .or_create(flags, translator, allocator)?;
+        let level_3 = self.walker.walk_level3(entry).or_create(flags, allocator)?;
 
         let entry = level_3.index_pin_mut(addr.page_table_index(Level3));
-        let level_2 = self
-            .walker
-            .walk_level2(entry)
-            .or_create(flags, translator, allocator)?;
+        let level_2 = self.walker.walk_level2(entry).or_create(flags, allocator)?;
 
         // SAFETY: we are the sole owner of this page and the entry will be valid
         unsafe {
@@ -143,13 +126,9 @@ where
         trace!("Mapping page: {:?} -> {:?}", &page, &frame);
 
         let level_4 = self.walker.level4();
-        let translator = self.walker.translator();
 
         let entry = level_4.index_pin_mut(addr.page_table_index(Level4));
-        let level_3 = self
-            .walker
-            .walk_level3(entry)
-            .or_create(flags, translator, allocator)?;
+        let level_3 = self.walker.walk_level3(entry).or_create(flags, allocator)?;
 
         // SAFETY: we are the sole owner of this page and the entry will be valid
         unsafe {

--- a/drivers/page_mapper/src/lib.rs
+++ b/drivers/page_mapper/src/lib.rs
@@ -65,11 +65,9 @@ where
 
         // SAFETY: we are the sole owner of this page and the entry will be valid
         unsafe {
-            let entry = level_1
-                .index_pin_mut(addr.page_table_index(Level1))
-                .get_unchecked_mut();
-            entry.set_flags(flags);
-            entry.set_frame(frame);
+            let mut entry = level_1.index_pin_mut(addr.page_table_index(Level1));
+            entry.as_mut().set_flags(flags);
+            entry.as_mut().set_frame(frame);
         }
 
         Ok(())
@@ -100,11 +98,9 @@ where
 
         // SAFETY: we are the sole owner of this page and the entry will be valid
         unsafe {
-            let entry = level_2
-                .index_pin_mut(addr.page_table_index(Level2))
-                .get_unchecked_mut();
-            entry.set_flags(flags | Flags::HUGE);
-            entry.set_frame(frame);
+            let mut entry = level_2.index_pin_mut(addr.page_table_index(Level2));
+            entry.as_mut().set_flags(flags | Flags::HUGE);
+            entry.as_mut().set_frame(frame);
         }
 
         Ok(())
@@ -132,11 +128,9 @@ where
 
         // SAFETY: we are the sole owner of this page and the entry will be valid
         unsafe {
-            let entry = level_3
-                .index_pin_mut(addr.page_table_index(Level3))
-                .get_unchecked_mut();
-            entry.set_flags(flags | Flags::HUGE);
-            entry.set_frame(frame);
+            let mut entry = level_3.index_pin_mut(addr.page_table_index(Level3));
+            entry.as_mut().set_flags(flags | Flags::HUGE);
+            entry.as_mut().set_frame(frame);
         }
         Ok(())
     }

--- a/drivers/page_mapper/src/walker.rs
+++ b/drivers/page_mapper/src/walker.rs
@@ -3,10 +3,10 @@ use core::pin::Pin;
 use libx64::{
     address::{PhysicalAddr, VirtualAddr},
     paging::{
-        entry::{Flags, PageEntry},
+        entry::Flags,
         frame::{FrameError, FrameTranslator},
         table::{Level1, Level2, Level2Walk, Level3, Level3Walk, Level4, PageLevel, PageTable},
-        NotGiantPageSize, NotHugePageSize, Page4Kb, PageCheck, PageSize,
+        NotGiantPageSize, NotHugePageSize, Page4Kb, PageCheck, PageSize, PinEntryMut, PinTableMut,
     },
 };
 
@@ -23,7 +23,11 @@ impl<T, const N: u64> PageWalker<T, N>
 where
     PageCheck<N>: PageSize,
 {
-    pub fn translator(&self) -> &T {
+    pub const fn new(translator: T) -> Self {
+        Self { translator }
+    }
+
+    pub const fn translator(&self) -> &T {
         &self.translator
     }
 }
@@ -36,18 +40,18 @@ where
     T: FrameTranslator<Level3, Page4Kb>,
     T: FrameTranslator<Level2, Page4Kb>,
 {
-    pub fn new(translator: T) -> Self {
-        Self { translator }
+    pub fn level4(&self) -> PinTableMut<'_, Level4> {
+        PageTable::new(libx64::control::cr3(), &self.translator)
     }
 
     pub fn try_translate_addr(&mut self, addr: VirtualAddr) -> Result<PhysicalAddr, FrameError> {
         let page = self.level4();
 
         let entry = page.index_pin_mut(addr.page_table_index(Level4));
-        let page = self.walk_level3(entry).map_err(|(_, err)| err)?;
+        let page = self.walk_level3(entry)?;
 
         let entry = page.index_pin_mut(addr.page_table_index(Level3));
-        let page = match self.walk_level2(entry).map_err(|(_, err)| err)? {
+        let page = match self.walk_level2(entry)? {
             Level3Walk::PageTable(table) => table,
 
             // SAFETY: we hold a valid huge page frame
@@ -58,7 +62,7 @@ where
 
         // SAFETY: Level 3 page table must exist since we check for existence in walk_level2
         let entry = page.index_pin_mut(addr.page_table_index(Level2));
-        let page = match self.walk_level1(entry).map_err(|(_, err)| err)? {
+        let page = match self.walk_level1(entry)? {
             Level2Walk::PageTable(table) => table,
             // SAFETY: we hold a valid huge page frame
             Level2Walk::HugePage(frame) => unsafe {
@@ -71,69 +75,99 @@ where
         page.as_ref().translate_with_index(index, addr)
     }
 
-    pub(crate) fn walk_level3<'a>(
-        &self,
-        entry: Pin<&'a mut PageEntry<Level4>>,
-    ) -> Result<Pin<&'a mut PageTable<Level3>>, (Pin<&'a mut PageEntry<Level4>>, FrameError)> {
-        PageTable::<Level4>::walk_next(entry.as_ref(), &self.translator).map_err(|err| (entry, err))
+    pub(crate) fn walk_level3(
+        &'a self,
+        entry: PinEntryMut<'a, Level4>,
+    ) -> Result<PinTableMut<'a, Level3>, WalkError<'a, T, Level4>> {
+        PageTable::<Level4>::walk_next(entry.as_ref(), &self.translator).map_err(|error| {
+            WalkError {
+                translator: &self.translator,
+                entry,
+                error,
+            }
+        })
     }
 
     pub(crate) fn walk_level2<'a>(
-        &self,
-        entry: Pin<&'a mut PageEntry<Level3>>,
-    ) -> Result<Level3Walk<'a>, (Pin<&'a mut PageEntry<Level3>>, FrameError)> {
-        match PageTable::<Level3>::walk_next(entry.as_ref(), &self.translator) {
-            Ok(table) => Ok(table),
-            Err(err) => Err((entry, err)),
-        }
+        &'a self,
+        entry: PinEntryMut<'a, Level3>,
+    ) -> Result<Level3Walk<'a>, WalkError<'a, T, Level3>> {
+        PageTable::<Level3>::walk_next(entry.as_ref(), &self.translator).map_err(|error| {
+            WalkError {
+                translator: &self.translator,
+                entry,
+                error,
+            }
+        })
     }
 
     pub(crate) fn walk_level1<'a>(
-        &self,
-        entry: Pin<&'a mut PageEntry<Level2>>,
-    ) -> Result<Level2Walk<'a>, (Pin<&'a mut PageEntry<Level2>>, FrameError)> {
-        PageTable::<Level2>::walk_next(entry.as_ref(), &self.translator).map_err(|err| (entry, err))
-    }
-
-    pub fn level4(&self) -> Pin<&mut PageTable<Level4>> {
-        PageTable::new(libx64::control::cr3(), &self.translator)
+        &'a self,
+        entry: PinEntryMut<'a, Level2>,
+    ) -> Result<Level2Walk<'a>, WalkError<'a, T, Level2>> {
+        PageTable::<Level2>::walk_next(entry.as_ref(), &self.translator).map_err(|error| {
+            WalkError {
+                translator: &self.translator,
+                entry,
+                error,
+            }
+        })
     }
 }
 
-pub trait WalkResultExt<'a, L, const N: u64>
+pub struct WalkError<'a, T, L>
+where
+    L: PageLevel,
+    T: FrameTranslator<L, Page4Kb>,
+{
+    translator: &'a T,
+    entry: PinEntryMut<'a, L>,
+    error: FrameError,
+}
+
+impl<'a, T, L> From<WalkError<'a, T, L>> for FrameError
+where
+    L: PageLevel,
+    T: FrameTranslator<L, Page4Kb>,
+{
+    fn from(this: WalkError<'a, T, L>) -> Self {
+        this.error
+    }
+}
+
+pub trait WalkResultExt<'a, T, L, const N: u64>
 where
     PageCheck<N>: PageSize,
+    T: FrameTranslator<L::Prev, Page4Kb>,
     L: PageLevel,
 {
-    fn or_create<T, A>(
-        self,
-        flags: Flags,
-        t: &T,
-        a: &mut A,
-    ) -> Result<Pin<&'a mut PageTable<L>>, FrameError>
+    fn or_create<A>(self, flags: Flags, a: &mut A) -> Result<PinTableMut<'a, L>, FrameError>
     where
-        T: FrameTranslator<L::Prev, Page4Kb>,
         A: FrameAllocator<N>;
 
-    fn try_into_table(self) -> Result<Pin<&'a mut PageTable<L>>, FrameError>;
+    fn try_into_table(self) -> Result<PinTableMut<'a, L>, FrameError>;
 }
 
-impl<'a> WalkResultExt<'a, Level3, Page4Kb>
-    for Result<Pin<&'a mut PageTable<Level3>>, (Pin<&'a mut PageEntry<Level4>>, FrameError)>
+impl<'a, T> WalkResultExt<'a, T, Level3, Page4Kb>
+    for Result<PinTableMut<'a, Level3>, WalkError<'a, T, Level4>>
+where
+    T: FrameTranslator<Level4, Page4Kb>,
 {
-    fn or_create<T, A>(
+    fn or_create<A>(
         self,
         flags: Flags,
-        t: &T,
         a: &mut A,
     ) -> Result<Pin<&'a mut PageTable<Level3>>, FrameError>
     where
-        T: FrameTranslator<Level4, Page4Kb>,
         A: FrameAllocator<Page4Kb>,
     {
         match self {
             Ok(table) => Ok(table),
-            Err((prev, FrameError::EntryMissing)) => {
+            Err(WalkError {
+                translator,
+                entry: prev,
+                error: FrameError::EntryMissing,
+            }) => {
                 let frame = a.alloc()?;
                 trace!("Allocating level3 page table");
 
@@ -144,36 +178,41 @@ impl<'a> WalkResultExt<'a, Level3, Page4Kb>
                     prev.set_flags(flags | Flags::PRESENT | Flags::RW);
                     prev.set_frame(frame);
 
-                    let mut page = t.translate_frame(frame);
+                    let mut page = translator.translate_frame(frame);
                     page.as_mut().get_unchecked_mut().zero();
                     Ok(page)
                 }
             }
-            Err((_, err)) => Err(err),
+            Err(error) => Err(error.error),
         }
     }
 
-    fn try_into_table(self) -> Result<Pin<&'a mut PageTable<Level3>>, FrameError> {
-        self.map_err(|(_, err)| err)
+    fn try_into_table(self) -> Result<PinTableMut<'a, Level3>, FrameError> {
+        Ok(self?)
     }
 }
 
-impl<'a> WalkResultExt<'a, Level2, Page4Kb>
-    for Result<Level3Walk<'a>, (Pin<&'a mut PageEntry<Level3>>, FrameError)>
+impl<'a, T> WalkResultExt<'a, T, Level2, Page4Kb>
+    for Result<Level3Walk<'a>, WalkError<'a, T, Level3>>
+where
+    T: FrameTranslator<Level3, Page4Kb>,
 {
-    fn or_create<T, A>(
+    fn or_create<A>(
         self,
         flags: Flags,
-        t: &T,
         a: &mut A,
     ) -> Result<Pin<&'a mut PageTable<Level2>>, FrameError>
     where
-        T: FrameTranslator<Level3, Page4Kb>,
         A: FrameAllocator<Page4Kb>,
     {
         match self {
             Ok(table) => Ok(table.try_into_table()?),
-            Err((prev, FrameError::EntryMissing)) => {
+
+            Err(WalkError {
+                translator,
+                entry: prev,
+                error: FrameError::EntryMissing,
+            }) => {
                 let frame = a.alloc()?;
                 trace!("Allocating level2 page table");
 
@@ -184,37 +223,41 @@ impl<'a> WalkResultExt<'a, Level2, Page4Kb>
                     prev.set_flags(flags | Flags::PRESENT | Flags::RW);
                     prev.set_frame(frame);
 
-                    let mut page = t.translate_frame(frame);
+                    let mut page = translator.translate_frame(frame);
                     page.as_mut().get_unchecked_mut().zero();
                     Ok(page)
                 }
             }
-            Err((_, err)) => Err(err),
+            Err(error) => Err(error.error),
         }
     }
 
-    fn try_into_table(self) -> Result<Pin<&'a mut PageTable<Level2>>, FrameError> {
-        self.map_err(|(_, err)| err)
+    fn try_into_table(self) -> Result<PinTableMut<'a, Level2>, FrameError> {
+        self.map_err(|err| err.error)
             .and_then(|table| table.try_into_table())
     }
 }
 
-impl<'a> WalkResultExt<'a, Level1, Page4Kb>
-    for Result<Level2Walk<'a>, (Pin<&'a mut PageEntry<Level2>>, FrameError)>
+impl<'a, T> WalkResultExt<'a, T, Level1, Page4Kb>
+    for Result<Level2Walk<'a>, WalkError<'a, T, Level2>>
+where
+    T: FrameTranslator<Level2, Page4Kb>,
 {
-    fn or_create<T, A>(
+    fn or_create<A>(
         self,
         flags: Flags,
-        t: &T,
         a: &mut A,
     ) -> Result<Pin<&'a mut PageTable<Level1>>, FrameError>
     where
-        T: FrameTranslator<Level2, Page4Kb>,
         A: FrameAllocator<Page4Kb>,
     {
         match self {
             Ok(table) => Ok(table.try_into_table()?),
-            Err((prev, FrameError::EntryMissing)) => {
+            Err(WalkError {
+                translator,
+                entry: prev,
+                error: FrameError::EntryMissing,
+            }) => {
                 let frame = a.alloc()?;
                 trace!("Allocating level1 page table");
 
@@ -225,17 +268,17 @@ impl<'a> WalkResultExt<'a, Level1, Page4Kb>
                     prev.set_flags(flags | Flags::PRESENT | Flags::RW);
                     prev.set_frame(frame);
 
-                    let mut page = t.translate_frame(frame);
+                    let mut page = translator.translate_frame(frame);
                     page.as_mut().get_unchecked_mut().zero();
                     Ok(page)
                 }
             }
-            Err((_, err)) => Err(err),
+            Err(error) => Err(error.error),
         }
     }
 
-    fn try_into_table(self) -> Result<Pin<&'a mut PageTable<Level1>>, FrameError> {
-        self.map_err(|(_, err)| err)
+    fn try_into_table(self) -> Result<PinTableMut<'a, Level1>, FrameError> {
+        self.map_err(|err| err.error)
             .and_then(|table| table.try_into_table())
     }
 }

--- a/kcore/src/kalloc/mod.rs
+++ b/kcore/src/kalloc/mod.rs
@@ -38,6 +38,10 @@ where
         self.len as usize
     }
 
+    pub const fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     pub const fn capacity(&self) -> usize {
         (Page4Kb / N) as usize
     }

--- a/libx64/src/paging/mod.rs
+++ b/libx64/src/paging/mod.rs
@@ -1,3 +1,5 @@
+use core::pin::Pin;
+
 use crate::{
     address::VirtualAddr,
     units::bits::{Gb, Kb, Mb},
@@ -7,6 +9,9 @@ pub mod entry;
 pub mod frame;
 pub mod page;
 pub mod table;
+
+pub type PinTableMut<'a, L> = Pin<&'a mut table::PageTable<L>>;
+pub type PinEntryMut<'a, L> = Pin<&'a mut entry::PageEntry<L>>;
 
 #[allow(non_upper_case_globals)]
 pub const Page4Kb: u64 = 4 * Kb;

--- a/libx64/src/paging/table.rs
+++ b/libx64/src/paging/table.rs
@@ -6,9 +6,11 @@ use crate::{
     paging::{
         entry::{MappedLevel2Page, MappedLevel3Page, PageEntry},
         frame::{FrameError, FrameTranslator, PhysicalFrame},
-        Page1Gb, Page2Mb, Page4Kb,
+        Page1Gb, Page2Mb, Page4Kb, PinEntryMut,
     },
 };
+
+use super::PinTableMut;
 
 #[derive(Debug)]
 #[repr(C, align(4096))]
@@ -20,13 +22,13 @@ pub struct PageTable<LEVEL: PageLevel> {
 
 impl<LEVEL: PageLevel> PageTable<LEVEL> {
     pub fn index_pin(self: Pin<&Self>, idx: PageTableIndex<LEVEL>) -> Pin<&PageEntry<LEVEL>> {
-        unsafe { self.map_unchecked(|page| &page[idx]) }
+        unsafe { self.map_unchecked(|page| page[idx].assume_init_ref()) }
     }
     pub fn index_pin_mut(
         self: Pin<&mut Self>,
         idx: PageTableIndex<LEVEL>,
-    ) -> Pin<&mut PageEntry<LEVEL>> {
-        unsafe { self.map_unchecked_mut(|page| &mut page[idx]) }
+    ) -> PinEntryMut<'_, LEVEL> {
+        unsafe { self.map_unchecked_mut(|page| page[idx].assume_init_mut()) }
     }
 }
 
@@ -37,14 +39,14 @@ impl PageTable<Level4> {
 
     pub fn walk_next<'a, 'b: 'a>(
         cr: Pin<&'a PageEntry<Level4>>,
-        translator: &dyn FrameTranslator<Level4, Page4Kb>,
+        translator: &'a dyn FrameTranslator<Level4, Page4Kb>,
     ) -> Result<Pin<&'b mut PageTable<Level3>>, FrameError> {
         unsafe { Ok(translator.translate_frame(cr.frame()?)) }
     }
 }
 
 pub enum Level3Walk<'a> {
-    PageTable(Pin<&'a mut PageTable<Level2>>),
+    PageTable(PinTableMut<'a, Level2>),
     HugePage(PhysicalFrame<Page1Gb>),
 }
 impl PageTable<Level3> {
@@ -72,7 +74,7 @@ impl PageTable<Level3> {
 }
 
 pub enum Level2Walk<'a> {
-    PageTable(Pin<&'a mut PageTable<Level1>>),
+    PageTable(PinTableMut<'a, Level1>),
     HugePage(PhysicalFrame<Page2Mb>),
 }
 
@@ -106,9 +108,15 @@ impl PageTable<Level1> {
         idx: PageTableIndex<Level1>,
         virt: VirtualAddr,
     ) -> Result<PhysicalAddr, FrameError> {
-        self[idx]
-            .frame()
-            .map(|f| f.ptr() + u64::from(virt.page_offset()))
+        // SAFETY: We return a pointer, unsafe should not be at call site, but at deref site.
+        // since we have a level 1 table, an entry and an index the page table should exist. The
+        // entry is, in the worst case, empty which is handled by the frame method.
+        unsafe {
+            self[idx]
+                .assume_init_ref()
+                .frame()
+                .map(|f| f.ptr() + u64::from(virt.page_offset()))
+        }
     }
 }
 
@@ -144,16 +152,22 @@ impl<T: PageLevel> core::fmt::Debug for PageTableIndex<T> {
 }
 
 impl<LEVEL: PageLevel> core::ops::Index<PageTableIndex<LEVEL>> for PageTable<LEVEL> {
-    type Output = PageEntry<LEVEL>;
+    type Output = core::mem::MaybeUninit<PageEntry<LEVEL>>;
 
     fn index(&self, idx: PageTableIndex<LEVEL>) -> &Self::Output {
-        &self.entries[idx.idx]
+        unsafe {
+            &*(&self.entries[idx.idx] as *const PageEntry<LEVEL>
+                as *const core::mem::MaybeUninit<PageEntry<LEVEL>>)
+        }
     }
 }
 
 impl<LEVEL: PageLevel> core::ops::IndexMut<PageTableIndex<LEVEL>> for PageTable<LEVEL> {
     fn index_mut(&mut self, idx: PageTableIndex<LEVEL>) -> &mut Self::Output {
-        &mut self.entries[idx.idx]
+        unsafe {
+            &mut *(&mut self.entries[idx.idx] as *mut PageEntry<LEVEL>
+                as *mut core::mem::MaybeUninit<PageEntry<LEVEL>>)
+        }
     }
 }
 


### PR DESCRIPTION
- Pass translator context in page walk error
- Create new types for Pinned entries, reducing code bloat
- Make page indexing return `MaybeUninit` so that it becomes unsafe to assume they are valid entries