### PR TITLE
Serialisation support for logs bootloader + kernel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "bitfield"
 version = "0.1.0"
 dependencies = [
@@ -33,6 +44,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytecheck"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "314889ea31cda264cb7c3d6e6e5c9415a987ecb0e72c17c00d36fbb881d34abe"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a2b3b92c135dae665a6f760205b89187638e83bed17ef3e44e83c712cf30600"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,9 +78,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
+checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -50,35 +88,61 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.18"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629316e42fe7c2a0b9a65b47d159ceaa5453ab14e8f0a3c5eedbb8cd55b4a445"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
 
 [[package]]
 name = "futures-task"
-version = "0.3.18"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabf1872aaab32c886832f2276d2f5399887e2bd613698a02359e4ea83f8de12"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
 name = "futures-util"
-version = "0.3.18"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d22213122356472061ac0f1ab2cee28d2bac8491410fd68c2af53d1cedb83e"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
  "futures-core",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
+dependencies = [
+ "ahash",
 ]
 
 [[package]]
@@ -139,6 +203,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "konsole"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "protocols",
+ "rkyv",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+
+[[package]]
 name = "libx64"
 version = "0.1.0"
 dependencies = [
@@ -162,10 +243,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "mio"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "noto-sans-mono-bitmap"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643bee6617a18c64f5a72ef358a9426d3682dc768db7c320825d3d936e2232d4"
+
+[[package]]
+name = "ntapi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "page_mapper"
@@ -177,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 
 [[package]]
 name = "pic"
@@ -191,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
 name = "pin-utils"
@@ -203,11 +328,38 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.30"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "protocols"
+version = "0.1.0"
+dependencies = [
+ "rkyv",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -215,17 +367,54 @@ name = "qemu_logger"
 version = "0.1.0"
 dependencies = [
  "kcore",
+ "libx64",
  "log",
+ "protocols",
+ "rkyv",
  "serialuart16550",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "b4af2ec4714533fcdf07e886f17025ace8b997b9ce51204ee69b6da831c3da57"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rend"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79af64b4b6362ffba04eef3a4e10829718a4896dac19daa741851c86781edf95"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5230ae2981a885590b0dc84e0b24c0ed23ad24f7adc0eb824b26cafa961f7c36"
+dependencies = [
+ "bytecheck",
+ "hashbrown",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc752d5925dbcb324522f3a4c93193d17f107b2e11810913aa3ad352fa01480"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -247,19 +436,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.134"
+name = "seahash"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b3c34c1690edf8174f5b289a336ab03f568a4460d8c6df75f2f3a692b3bc6a"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "serde"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.134"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784ed1fbfa13fe191077537b0d70ec8ad1e903cfe04831da608aa36457cb653d"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -276,14 +471,65 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "1.0.80"
+name = "socket2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tokio"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
+dependencies = [
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64910e1b9c1901aaf5375561e35b9c057d95ff41a44ede043a03e09279eabaf1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -300,6 +546,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vesa"
@@ -319,6 +571,40 @@ dependencies = [
  "kcore",
  "libx64",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xmas-elf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ members = [
     "kcore",  
     "kalloc",
     "bootloader",
+    
+    "konsole",
+    "protocols",
 
     "utils/bitfield",
     "utils/interrupt_list",

--- a/bootloader/src/bin/bios.rs
+++ b/bootloader/src/bin/bios.rs
@@ -182,7 +182,7 @@ fn create_page_tables(frame_allocator: &mut impl FrameAllocator<Page4Kb>) -> Pag
         let kernel = unsafe {
             let ptr = addr.ptr().unwrap().as_mut();
             *ptr = PageTable::new_zero();
-            OffsetMapper::from_p4(ptr, phys_offset)
+            OffsetMapper::from_p4(core::pin::Pin::new_unchecked(ptr), phys_offset)
         };
         (kernel, frame)
     };

--- a/drivers/serialuart16550/src/lib.rs
+++ b/drivers/serialuart16550/src/lib.rs
@@ -33,6 +33,7 @@ macro_rules! wait_for {
     };
 }
 
+#[derive(Debug)]
 pub struct SerialPort {
     data: RWPort<u8>,
     int_en: WPort<u8>,

--- a/kcore/src/io/cursor.rs
+++ b/kcore/src/io/cursor.rs
@@ -1,0 +1,28 @@
+pub struct Cursor<'a> {
+    data: &'a mut [u8],
+    cursor: usize,
+}
+
+impl<'a> Cursor<'a> {
+    pub fn new(data: &'a mut [u8]) -> Self {
+        Self { data, cursor: 0 }
+    }
+
+    pub fn buffer(&self) -> &[u8] {
+        &self.data[..self.cursor]
+    }
+}
+
+impl<'a> core::fmt::Write for Cursor<'a> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        let prev = self.cursor;
+        self.cursor += s.as_bytes().len();
+
+        if self.cursor > self.data.len() {
+            Err(core::fmt::Error)
+        } else {
+            self.data[prev..self.cursor].copy_from_slice(s.as_bytes());
+            Ok(())
+        }
+    }
+}

--- a/kcore/src/io/mod.rs
+++ b/kcore/src/io/mod.rs
@@ -1,0 +1,3 @@
+mod cursor;
+
+pub use cursor::Cursor;

--- a/kcore/src/lib.rs
+++ b/kcore/src/lib.rs
@@ -14,6 +14,7 @@ extern crate log;
 
 pub mod either;
 
+pub mod io;
 pub mod ptr;
 
 pub mod queue {

--- a/konsole/Cargo.toml
+++ b/konsole/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "konsole"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies.bytes]
+version = "1"
+
+[dependencies.protocols]
+path = "../protocols"
+features = ["log", "alloc"]
+default-features=false
+
+[dependencies.tokio]
+version = "1"
+features = ["net", "rt", "macros", "io-util", "io-std"]
+default-features=false
+
+[dependencies.tokio-util]
+version = "0.7"
+features = ["codec"]
+default-features=false
+
+[dependencies.rkyv]
+features = ["size_32", "strict"]
+version = "0.7"

--- a/konsole/src/codec.rs
+++ b/konsole/src/codec.rs
@@ -1,0 +1,58 @@
+use std::io;
+
+use bytes::BytesMut;
+use rkyv::{util, Archive};
+
+use protocols::log::{LogHeader, LogMessage, HEADER_SIZE};
+
+enum DecoderState {
+    WaitingForHeader,
+    ReadingMessage(usize),
+}
+
+pub struct LogDecoder {
+    state: DecoderState,
+}
+
+impl LogDecoder {
+    pub const fn new() -> Self {
+        Self {
+            state: DecoderState::WaitingForHeader,
+        }
+    }
+
+    pub fn decode_ref<'a>(
+        &mut self,
+        src: &'a mut BytesMut,
+    ) -> Result<Option<&'a <LogMessage as Archive>::Archived>, io::Error> {
+        match self.state {
+            DecoderState::WaitingForHeader => {
+                if src.len() < HEADER_SIZE {
+                    return Ok(None);
+                }
+                let header =
+                    match unsafe { rkyv::from_bytes_unchecked::<LogHeader>(&src[..HEADER_SIZE]) } {
+                        Ok(header) => header,
+                        Err(_) => return Ok(None),
+                    };
+                if header.size == 0 {
+                    return Ok(None);
+                }
+
+                src.reserve(HEADER_SIZE + header.size);
+                drop(src.split_to(HEADER_SIZE));
+
+                self.state = DecoderState::ReadingMessage(header.size);
+                return Ok(None);
+            }
+            DecoderState::ReadingMessage(n) => {
+                if src.len() >= n {
+                    let message = unsafe { util::archived_unsized_root::<LogMessage>(&src[..n]) };
+                    self.state = DecoderState::WaitingForHeader;
+                    return Ok(Some(message));
+                }
+                return Ok(None);
+            }
+        }
+    }
+}

--- a/konsole/src/main.rs
+++ b/konsole/src/main.rs
@@ -1,0 +1,75 @@
+mod codec;
+
+use std::io;
+
+use protocols::log::ArchivedLevel;
+
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> io::Result<()> {
+    let mut addr = std::env::args().skip(1);
+    let addr = addr.next().ok_or(io::Error::new(
+        io::ErrorKind::Other,
+        "missing server address",
+    ))?;
+
+    let listener = TcpListener::bind(addr).await?;
+
+    let (mut stream, _) = listener.accept().await?;
+
+    let mut stdout = tokio::io::stdout();
+    let mut codec = codec::LogDecoder::new();
+
+    let mut bytes = bytes::BytesMut::new();
+    while let Ok(n) = stream.read_buf(&mut bytes).await {
+        if n == 0 {
+            return Ok(());
+        }
+        let message = match codec.decode_ref(&mut bytes)? {
+            Some(message) => message,
+            None => continue,
+        };
+        let fmt_log = match message.level {
+            ArchivedLevel::Error => {
+                format!(
+                    "[\u{001b}[31;1mERROR\u{001b}[0m][{}:{}] > {}",
+                    &*message.path, message.line, &*message.message
+                )
+            }
+            ArchivedLevel::Warn => {
+                format!(
+                    "[\u{001b}[33;1mWARN\u{001b}[0m][{}:{}] > {}",
+                    &*message.path, message.line, &*message.message
+                )
+            }
+
+            ArchivedLevel::Info => {
+                format!(
+                    "[\u{001b}[34;1mINFO\u{001b}[0m][{}:{}] > {}",
+                    &*message.path, message.line, &*message.message
+                )
+            }
+            ArchivedLevel::Debug => {
+                format!(
+                    "\u{001b}[4;1m[DEBUG][{}:{}]\u{001b}[0m > {}",
+                    &*message.path, message.line, &*message.message
+                )
+            }
+            ArchivedLevel::Trace => {
+                format!(
+                    "\u{001b}[38;2;128;128;128;2m[TRACE][{}:{}] > {}\u{001b}[0m",
+                    &*message.path, message.line, &*message.message
+                )
+            }
+        };
+
+        stdout.write_all(fmt_log.as_bytes()).await?;
+        stdout.write(b"\n").await?;
+        bytes.clear();
+    }
+    Ok(())
+}

--- a/protocols/Cargo.toml
+++ b/protocols/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "protocols"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+default = []
+alloc = ["rkyv/alloc"]
+log = []
+
+[dependencies.rkyv]
+version = "0.7"
+features = ["size_32", "strict"]
+default-features = false

--- a/protocols/src/lib.rs
+++ b/protocols/src/lib.rs
@@ -1,0 +1,12 @@
+#![no_std]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(feature = "log")]
+pub mod log;
+
+#[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+pub enum Noop {
+    Noop = 0,
+}

--- a/protocols/src/log.rs
+++ b/protocols/src/log.rs
@@ -1,0 +1,46 @@
+use rkyv::{with::RefAsBox, Archive, Serialize};
+
+#[derive(
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+    Debug,
+    Clone,
+    Copy,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+)]
+#[archive_attr(derive(Debug, Clone, Copy))]
+pub enum Level {
+    Error = 0,
+    Warn = 1,
+    Info = 2,
+    Debug = 3,
+    Trace = 4,
+}
+
+pub const HEADER_SIZE: usize = core::mem::size_of::<<LogHeader as rkyv::Archive>::Archived>();
+
+// NOTE: protocols are built with size_32 for now
+// #[cfg(feature = "rkyv/size_32")]
+pub const SIZE_PAD: usize = 4;
+
+#[derive(Archive, Serialize, rkyv::Deserialize, Debug)]
+pub struct LogHeader {
+    pub size: usize,
+}
+
+#[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize, Debug)]
+pub struct LogMessage<'a> {
+    pub level: Level,
+    pub line: u32,
+
+    #[with(rkyv::with::RefAsBox)]
+    pub path: &'a str,
+
+    #[with(RefAsBox)]
+    pub message: &'a str,
+}

--- a/utils/qemu_logger/Cargo.toml
+++ b/utils/qemu_logger/Cargo.toml
@@ -10,3 +10,10 @@ log = {version="0.4", default-features=false}
 
 serialuart16550 = {path = "../../drivers/serialuart16550"}
 kcore = {path = "../../kcore"}
+libx64 = {path = "../../libx64"}
+protocols = {path ="../../protocols", features=["log"], default-features=false}
+
+[dependencies.rkyv]
+version = "0.7"
+features = ["size_32", "strict"]
+default-features = false


### PR DESCRIPTION
This commit introduces rkyv as the serialization framework for the
kernel. It also implements the serialisation of logs and sends them via
tcp to a custom kernel console (just forwards to stdout for now)!